### PR TITLE
Update submodules for imgui (docking branch)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "glm"]
+[submodule "imgui"]
 	path = imgui
-	url = https://github.com/ocornut/imgui
+	url = https://github.com/ocornut/imgui.git


### PR DESCRIPTION
The imgui submodules was not added to the project correctly which resulted in the project not being able to compile.

This commit should fix that.